### PR TITLE
Cache hybrid config for miner batch sizing

### DIFF
--- a/Core-Blockchain/node_src/common/hybrid/hybrid_processor.go
+++ b/Core-Blockchain/node_src/common/hybrid/hybrid_processor.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/common/gopool"
 	"github.com/ethereum/go-ethereum/common/gpu"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // HybridProcessor combines CPU and GPU processing with intelligent load balancing
@@ -18,47 +18,66 @@ type HybridProcessor struct {
 	// Processing components
 	cpuProcessor *gopool.ParallelProcessor
 	gpuProcessor *gpu.GPUProcessor
-	
+
 	// Load balancing
 	loadBalancer *LoadBalancer
-	
+
 	// Configuration
-	config       *HybridConfig
-	
+	config *HybridConfig
+
 	// Statistics
-	mu           sync.RWMutex
-	stats        HybridStats
-	
+	mu    sync.RWMutex
+	stats HybridStats
+
 	// Shutdown coordination
-	ctx          context.Context
-	cancel       context.CancelFunc
-	wg           sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// GetConfig returns a defensive copy of the active hybrid configuration.
+func (h *HybridProcessor) GetConfig() *HybridConfig {
+	if h == nil || h.config == nil {
+		return nil
+	}
+
+	cfgCopy := *h.config
+	if h.config.CPUConfig != nil {
+		cpuCopy := *h.config.CPUConfig
+		cfgCopy.CPUConfig = &cpuCopy
+	}
+	if h.config.GPUConfig != nil {
+		gpuCopy := *h.config.GPUConfig
+		cfgCopy.GPUConfig = &gpuCopy
+	}
+
+	return &cfgCopy
 }
 
 // HybridConfig holds configuration for hybrid processing
 type HybridConfig struct {
 	// CPU Configuration
-	CPUConfig    *gopool.ProcessorConfig `json:"cpuConfig"`
-	
+	CPUConfig *gopool.ProcessorConfig `json:"cpuConfig"`
+
 	// GPU Configuration
-	GPUConfig    *gpu.GPUConfig `json:"gpuConfig"`
-	
+	GPUConfig *gpu.GPUConfig `json:"gpuConfig"`
+
 	// Load Balancing Configuration
-	EnableGPU              bool    `json:"enableGpu"`
-	GPUThreshold           int     `json:"gpuThreshold"`           // Minimum batch size for GPU
-	CPUGPURatio            float64 `json:"cpuGpuRatio"`            // 0.0 = all CPU, 1.0 = all GPU
-	AdaptiveLoadBalancing  bool    `json:"adaptiveLoadBalancing"`  // Enable adaptive load balancing
-	PerformanceMonitoring  bool    `json:"performanceMonitoring"`  // Enable performance monitoring
-	
+	EnableGPU             bool    `json:"enableGpu"`
+	GPUThreshold          int     `json:"gpuThreshold"`          // Minimum batch size for GPU
+	CPUGPURatio           float64 `json:"cpuGpuRatio"`           // 0.0 = all CPU, 1.0 = all GPU
+	AdaptiveLoadBalancing bool    `json:"adaptiveLoadBalancing"` // Enable adaptive load balancing
+	PerformanceMonitoring bool    `json:"performanceMonitoring"` // Enable performance monitoring
+
 	// Performance Thresholds
-	MaxCPUUtilization      float64 `json:"maxCpuUtilization"`      // Max CPU utilization before GPU offload
-	MaxGPUUtilization      float64 `json:"maxGpuUtilization"`      // Max GPU utilization
-	LatencyThreshold       time.Duration `json:"latencyThreshold"` // Max acceptable latency
-	ThroughputTarget       uint64  `json:"throughputTarget"`       // Target TPS
-	
+	MaxCPUUtilization float64       `json:"maxCpuUtilization"` // Max CPU utilization before GPU offload
+	MaxGPUUtilization float64       `json:"maxGpuUtilization"` // Max GPU utilization
+	LatencyThreshold  time.Duration `json:"latencyThreshold"`  // Max acceptable latency
+	ThroughputTarget  uint64        `json:"throughputTarget"`  // Target TPS
+
 	// Memory Management
-	MaxMemoryUsage         uint64  `json:"maxMemoryUsage"`         // Max total memory usage
-	GPUMemoryReservation   uint64  `json:"gpuMemoryReservation"`   // Reserved GPU memory
+	MaxMemoryUsage       uint64 `json:"maxMemoryUsage"`       // Max total memory usage
+	GPUMemoryReservation uint64 `json:"gpuMemoryReservation"` // Reserved GPU memory
 }
 
 // DefaultHybridConfig returns optimized hybrid configuration for NVIDIA RTX 4000 SFF Ada (20GB VRAM) and 16+ core CPUs
@@ -67,14 +86,14 @@ func DefaultHybridConfig() *HybridConfig {
 		CPUConfig:             gopool.DefaultProcessorConfig(),
 		GPUConfig:             gpu.DefaultGPUConfig(),
 		EnableGPU:             true,
-		GPUThreshold:          2000,  // Higher threshold - Use GPU for batches >= 2000 (balanced utilization)
-		CPUGPURatio:           0.20,  // 20% GPU, 80% CPU for balanced utilization
+		GPUThreshold:          2000, // Higher threshold - Use GPU for batches >= 2000 (balanced utilization)
+		CPUGPURatio:           0.20, // 20% GPU, 80% CPU for balanced utilization
 		AdaptiveLoadBalancing: true,
 		PerformanceMonitoring: true,
-		MaxCPUUtilization:     0.85,  // 85% max CPU usage (sustainable)
-		MaxGPUUtilization:     0.90,  // 90% max GPU usage (sustainable)
-        LatencyThreshold:      50 * time.Millisecond,  // More realistic latency target
-        ThroughputTarget:      3000000, // 3M TPS target (aligned with miner/env defaults)
+		MaxCPUUtilization:     0.85,                    // 85% max CPU usage (sustainable)
+		MaxGPUUtilization:     0.90,                    // 90% max GPU usage (sustainable)
+		LatencyThreshold:      50 * time.Millisecond,   // More realistic latency target
+		ThroughputTarget:      3000000,                 // 3M TPS target (aligned with miner/env defaults)
 		MaxMemoryUsage:        64 * 1024 * 1024 * 1024, // 64GB total system memory
 		GPUMemoryReservation:  12 * 1024 * 1024 * 1024, // 12GB GPU reserved (safer limit)
 	}
@@ -82,16 +101,16 @@ func DefaultHybridConfig() *HybridConfig {
 
 // LoadBalancer manages workload distribution between CPU and GPU
 type LoadBalancer struct {
-	mu                    sync.RWMutex
-	cpuUtilization        float64
-	gpuUtilization        float64
-	avgCPULatency         time.Duration
-	avgGPULatency         time.Duration
-	cpuThroughput         uint64
-	gpuThroughput         uint64
-	adaptiveRatio         float64
-	lastAdjustment        time.Time
-	performanceHistory    []PerformanceSnapshot
+	mu                 sync.RWMutex
+	cpuUtilization     float64
+	gpuUtilization     float64
+	avgCPULatency      time.Duration
+	avgGPULatency      time.Duration
+	cpuThroughput      uint64
+	gpuThroughput      uint64
+	adaptiveRatio      float64
+	lastAdjustment     time.Time
+	performanceHistory []PerformanceSnapshot
 }
 
 // PerformanceSnapshot captures performance metrics at a point in time
@@ -106,16 +125,16 @@ type PerformanceSnapshot struct {
 
 // HybridStats holds statistics for hybrid processing
 type HybridStats struct {
-	TotalProcessed        uint64        `json:"totalProcessed"`
-	CPUProcessed          uint64        `json:"cpuProcessed"`
-	GPUProcessed          uint64        `json:"gpuProcessed"`
-	AvgLatency            time.Duration `json:"avgLatency"`
-	CurrentTPS            uint64        `json:"currentTps"`
-	CPUUtilization        float64       `json:"cpuUtilization"`
-	GPUUtilization        float64       `json:"gpuUtilization"`
-	LoadBalancingRatio    float64       `json:"loadBalancingRatio"`
-	MemoryUsage           uint64        `json:"memoryUsage"`
-	GPUMemoryUsage        uint64        `json:"gpuMemoryUsage"`
+	TotalProcessed     uint64        `json:"totalProcessed"`
+	CPUProcessed       uint64        `json:"cpuProcessed"`
+	GPUProcessed       uint64        `json:"gpuProcessed"`
+	AvgLatency         time.Duration `json:"avgLatency"`
+	CurrentTPS         uint64        `json:"currentTps"`
+	CPUUtilization     float64       `json:"cpuUtilization"`
+	GPUUtilization     float64       `json:"gpuUtilization"`
+	LoadBalancingRatio float64       `json:"loadBalancingRatio"`
+	MemoryUsage        uint64        `json:"memoryUsage"`
+	GPUMemoryUsage     uint64        `json:"gpuMemoryUsage"`
 }
 
 // NewHybridProcessor creates a new hybrid processor
@@ -123,16 +142,16 @@ func NewHybridProcessor(config *HybridConfig) (*HybridProcessor, error) {
 	if config == nil {
 		config = DefaultHybridConfig()
 	}
-	
+
 	ctx, cancel := context.WithCancel(context.Background())
-	
+
 	// Initialize CPU processor
 	cpuProcessor, err := gopool.NewParallelProcessor(config.CPUConfig)
 	if err != nil {
 		cancel()
 		return nil, err
 	}
-	
+
 	// Initialize GPU processor if enabled
 	var gpuProcessor *gpu.GPUProcessor
 	if config.EnableGPU {
@@ -142,14 +161,14 @@ func NewHybridProcessor(config *HybridConfig) (*HybridProcessor, error) {
 			config.EnableGPU = false
 		}
 	}
-	
+
 	// Initialize load balancer
 	loadBalancer := &LoadBalancer{
 		adaptiveRatio:      config.CPUGPURatio,
 		lastAdjustment:     time.Now(),
 		performanceHistory: make([]PerformanceSnapshot, 0, 100),
 	}
-	
+
 	processor := &HybridProcessor{
 		cpuProcessor: cpuProcessor,
 		gpuProcessor: gpuProcessor,
@@ -158,18 +177,18 @@ func NewHybridProcessor(config *HybridConfig) (*HybridProcessor, error) {
 		ctx:          ctx,
 		cancel:       cancel,
 	}
-	
+
 	// Start monitoring and load balancing
 	if config.PerformanceMonitoring {
 		processor.wg.Add(1)
 		go processor.performanceMonitor()
 	}
-	
+
 	if config.AdaptiveLoadBalancing {
 		processor.wg.Add(1)
 		go processor.adaptiveLoadBalancer()
 	}
-	
+
 	log.Info("Hybrid processor initialized",
 		"cpuEnabled", true,
 		"gpuEnabled", config.EnableGPU,
@@ -187,7 +206,7 @@ func NewHybridProcessor(config *HybridConfig) (*HybridProcessor, error) {
 			return "None"
 		}(),
 	)
-	
+
 	return processor, nil
 }
 
@@ -197,13 +216,13 @@ func (h *HybridProcessor) ProcessTransactionsBatch(txs []*types.Transaction, cal
 		callback(nil, nil)
 		return nil
 	}
-	
+
 	start := time.Now()
 	batchSize := len(txs)
-	
+
 	// Determine processing strategy
 	strategy := h.determineProcessingStrategy(batchSize)
-	
+
 	switch strategy {
 	case ProcessingStrategyCPUOnly:
 		return h.processCPUOnly(txs, callback, start)
@@ -230,17 +249,17 @@ func (h *HybridProcessor) determineProcessingStrategy(batchSize int) ProcessingS
 	if !h.config.EnableGPU || h.gpuProcessor == nil {
 		return ProcessingStrategyCPUOnly
 	}
-	
+
 	// Small batches go to CPU
 	if batchSize < h.config.GPUThreshold {
 		return ProcessingStrategyCPUOnly
 	}
-	
+
 	h.loadBalancer.mu.RLock()
 	cpuUtil := h.loadBalancer.cpuUtilization
 	gpuUtil := h.loadBalancer.gpuUtilization
 	h.loadBalancer.mu.RUnlock()
-	
+
 	// If CPU is overloaded, prefer GPU
 	if cpuUtil > h.config.MaxCPUUtilization {
 		if gpuUtil < h.config.MaxGPUUtilization {
@@ -248,17 +267,17 @@ func (h *HybridProcessor) determineProcessingStrategy(batchSize int) ProcessingS
 		}
 		return ProcessingStrategyHybrid
 	}
-	
+
 	// If GPU is underutilized and batch is large, use hybrid
 	if batchSize > h.config.GPUThreshold*2 && gpuUtil < 0.5 {
 		return ProcessingStrategyHybrid
 	}
-	
+
 	// Default to GPU for large batches
 	if batchSize > h.config.GPUThreshold*5 {
 		return ProcessingStrategyGPUOnly
 	}
-	
+
 	return ProcessingStrategyCPUOnly
 }
 
@@ -267,7 +286,7 @@ func (h *HybridProcessor) processCPUOnly(txs []*types.Transaction, callback func
 	results := make([]*TransactionResult, len(txs))
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	
+
 	// Process in parallel using CPU workers
 	batchSize := 100 // Process in smaller batches
 	for i := 0; i < len(txs); i += batchSize {
@@ -275,14 +294,14 @@ func (h *HybridProcessor) processCPUOnly(txs []*types.Transaction, callback func
 		if end > len(txs) {
 			end = len(txs)
 		}
-		
+
 		wg.Add(1)
 		batch := txs[i:end]
 		batchStart := i
-		
+
 		err := h.cpuProcessor.SubmitTxTask(func() error {
 			defer wg.Done()
-			
+
 			// Process batch
 			batchResults := make([]*TransactionResult, len(batch))
 			for j, tx := range batch {
@@ -293,27 +312,27 @@ func (h *HybridProcessor) processCPUOnly(txs []*types.Transaction, callback func
 					Processed: true,
 				}
 			}
-			
+
 			// Store results
 			mu.Lock()
 			copy(results[batchStart:batchStart+len(batch)], batchResults)
 			mu.Unlock()
-			
+
 			return nil
 		}, nil)
-		
+
 		if err != nil {
 			return err
 		}
 	}
-	
+
 	// Wait for completion
 	wg.Wait()
-	
+
 	// Update statistics
 	duration := time.Since(start)
 	h.updateStats(uint64(len(txs)), 0, duration, ProcessingStrategyCPUOnly)
-	
+
 	callback(results, nil)
 	return nil
 }
@@ -323,14 +342,14 @@ func (h *HybridProcessor) processGPUOnly(txs []*types.Transaction, callback func
 	if h.gpuProcessor == nil {
 		return h.processCPUOnly(txs, callback, start)
 	}
-	
+
 	// Process transactions using GPU
 	err := h.gpuProcessor.ProcessTransactionsBatch(txs, func(results []*gpu.TxResult, err error) {
 		if err != nil {
 			callback(nil, err)
 			return
 		}
-		
+
 		// Convert GPU results to hybrid results
 		hybridResults := make([]*TransactionResult, len(results))
 		for i, result := range results {
@@ -342,14 +361,14 @@ func (h *HybridProcessor) processGPUOnly(txs []*types.Transaction, callback func
 				Processed: true,
 			}
 		}
-		
+
 		// Update statistics
 		duration := time.Since(start)
 		h.updateStats(0, uint64(len(txs)), duration, ProcessingStrategyGPUOnly)
-		
+
 		callback(hybridResults, nil)
 	})
-	
+
 	return err
 }
 
@@ -358,39 +377,39 @@ func (h *HybridProcessor) processHybrid(txs []*types.Transaction, callback func(
 	if h.gpuProcessor == nil {
 		return h.processCPUOnly(txs, callback, start)
 	}
-	
+
 	// Determine split ratio
 	h.loadBalancer.mu.RLock()
 	ratio := h.loadBalancer.adaptiveRatio
 	h.loadBalancer.mu.RUnlock()
-	
+
 	// Split transactions
 	gpuCount := int(float64(len(txs)) * ratio)
 	cpuCount := len(txs) - gpuCount
-	
+
 	gpuTxs := txs[:gpuCount]
 	cpuTxs := txs[gpuCount:]
-	
+
 	results := make([]*TransactionResult, len(txs))
 	var wg sync.WaitGroup
 	var processingError error
 	var mu sync.Mutex
-	
+
 	// Process GPU batch
 	if len(gpuTxs) > 0 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			
+
 			err := h.gpuProcessor.ProcessTransactionsBatch(gpuTxs, func(gpuResults []*gpu.TxResult, err error) {
 				mu.Lock()
 				defer mu.Unlock()
-				
+
 				if err != nil {
 					processingError = err
 					return
 				}
-				
+
 				// Convert and store GPU results
 				for i, result := range gpuResults {
 					results[i] = &TransactionResult{
@@ -402,7 +421,7 @@ func (h *HybridProcessor) processHybrid(txs []*types.Transaction, callback func(
 					}
 				}
 			})
-			
+
 			if err != nil {
 				mu.Lock()
 				processingError = err
@@ -410,26 +429,26 @@ func (h *HybridProcessor) processHybrid(txs []*types.Transaction, callback func(
 			}
 		}()
 	}
-	
+
 	// Process CPU batch
 	if len(cpuTxs) > 0 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			
+
 			err := h.processCPUBatch(cpuTxs, func(cpuResults []*TransactionResult, err error) {
 				mu.Lock()
 				defer mu.Unlock()
-				
+
 				if err != nil {
 					processingError = err
 					return
 				}
-				
+
 				// Store CPU results
 				copy(results[gpuCount:], cpuResults)
 			})
-			
+
 			if err != nil {
 				mu.Lock()
 				processingError = err
@@ -437,19 +456,19 @@ func (h *HybridProcessor) processHybrid(txs []*types.Transaction, callback func(
 			}
 		}()
 	}
-	
+
 	// Wait for both to complete
 	wg.Wait()
-	
+
 	if processingError != nil {
 		callback(nil, processingError)
 		return processingError
 	}
-	
+
 	// Update statistics
 	duration := time.Since(start)
 	h.updateStats(uint64(cpuCount), uint64(gpuCount), duration, ProcessingStrategyHybrid)
-	
+
 	callback(results, nil)
 	return nil
 }
@@ -457,7 +476,7 @@ func (h *HybridProcessor) processHybrid(txs []*types.Transaction, callback func(
 // processCPUBatch processes a batch using CPU
 func (h *HybridProcessor) processCPUBatch(txs []*types.Transaction, callback func([]*TransactionResult, error)) error {
 	results := make([]*TransactionResult, len(txs))
-	
+
 	// Simple CPU processing
 	for i, tx := range txs {
 		results[i] = &TransactionResult{
@@ -467,7 +486,7 @@ func (h *HybridProcessor) processCPUBatch(txs []*types.Transaction, callback fun
 			Processed: true,
 		}
 	}
-	
+
 	callback(results, nil)
 	return nil
 }
@@ -485,24 +504,24 @@ type TransactionResult struct {
 func (h *HybridProcessor) updateStats(cpuProcessed, gpuProcessed uint64, duration time.Duration, strategy ProcessingStrategy) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	
+
 	h.stats.TotalProcessed += cpuProcessed + gpuProcessed
 	h.stats.CPUProcessed += cpuProcessed
 	h.stats.GPUProcessed += gpuProcessed
-	
+
 	// Update average latency
 	if h.stats.AvgLatency == 0 {
 		h.stats.AvgLatency = duration
 	} else {
 		h.stats.AvgLatency = (h.stats.AvgLatency + duration) / 2
 	}
-	
+
 	// Calculate current TPS
 	if duration > 0 {
 		currentTPS := uint64(float64(cpuProcessed+gpuProcessed) / duration.Seconds())
 		h.stats.CurrentTPS = currentTPS
 	}
-	
+
 	// Update load balancing ratio
 	if h.stats.TotalProcessed > 0 {
 		h.stats.LoadBalancingRatio = float64(h.stats.GPUProcessed) / float64(h.stats.TotalProcessed)
@@ -512,10 +531,10 @@ func (h *HybridProcessor) updateStats(cpuProcessed, gpuProcessed uint64, duratio
 // performanceMonitor continuously monitors system performance
 func (h *HybridProcessor) performanceMonitor() {
 	defer h.wg.Done()
-	
+
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	
+
 	for {
 		select {
 		case <-h.ctx.Done():
@@ -532,7 +551,7 @@ func (h *HybridProcessor) collectPerformanceMetrics() {
 	if h == nil || h.loadBalancer == nil {
 		return
 	}
-	
+
 	// Get CPU stats with nil check
 	var cpuUtil float64
 	var avgCPULatency time.Duration
@@ -543,7 +562,7 @@ func (h *HybridProcessor) collectPerformanceMetrics() {
 		}
 		avgCPULatency = cpuStats.AvgProcessTime
 	}
-	
+
 	// Get GPU stats with nil check
 	var gpuUtil float64
 	var avgGPULatency time.Duration
@@ -556,7 +575,7 @@ func (h *HybridProcessor) collectPerformanceMetrics() {
 			avgGPULatency = gpuStats.AvgTxTime
 		}
 	}
-	
+
 	// Update load balancer metrics with safety checks
 	if h.loadBalancer != nil {
 		h.loadBalancer.mu.Lock()
@@ -564,7 +583,7 @@ func (h *HybridProcessor) collectPerformanceMetrics() {
 		h.loadBalancer.gpuUtilization = gpuUtil
 		h.loadBalancer.avgCPULatency = avgCPULatency
 		h.loadBalancer.avgGPULatency = avgGPULatency
-		
+
 		// Add performance snapshot
 		snapshot := PerformanceSnapshot{
 			Timestamp:     time.Now(),
@@ -574,19 +593,19 @@ func (h *HybridProcessor) collectPerformanceMetrics() {
 			GPUThroughput: h.stats.GPUProcessed,
 			TotalTPS:      h.stats.CurrentTPS,
 		}
-		
+
 		h.loadBalancer.performanceHistory = append(h.loadBalancer.performanceHistory, snapshot)
 		if len(h.loadBalancer.performanceHistory) > 100 {
 			h.loadBalancer.performanceHistory = h.loadBalancer.performanceHistory[1:]
 		}
 		h.loadBalancer.mu.Unlock()
 	}
-	
+
 	// Update hybrid stats with safety checks
 	h.mu.Lock()
 	h.stats.CPUUtilization = cpuUtil
 	h.stats.GPUUtilization = gpuUtil
-	
+
 	// Update memory usage (simplified)
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
@@ -597,10 +616,10 @@ func (h *HybridProcessor) collectPerformanceMetrics() {
 // adaptiveLoadBalancer adjusts the CPU/GPU ratio based on performance
 func (h *HybridProcessor) adaptiveLoadBalancer() {
 	defer h.wg.Done()
-	
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
-	
+
 	for {
 		select {
 		case <-h.ctx.Done():
@@ -615,39 +634,39 @@ func (h *HybridProcessor) adaptiveLoadBalancer() {
 func (h *HybridProcessor) adjustLoadBalancing() {
 	h.loadBalancer.mu.Lock()
 	defer h.loadBalancer.mu.Unlock()
-	
+
 	// Don't adjust too frequently
 	if time.Since(h.loadBalancer.lastAdjustment) < 10*time.Second {
 		return
 	}
-	
+
 	cpuUtil := h.loadBalancer.cpuUtilization
 	gpuUtil := h.loadBalancer.gpuUtilization
 	currentRatio := h.loadBalancer.adaptiveRatio
-	
+
 	// Adjustment logic
 	newRatio := currentRatio
-	
+
 	// If CPU is overloaded, shift more work to GPU
 	if cpuUtil > h.config.MaxCPUUtilization && gpuUtil < h.config.MaxGPUUtilization {
 		newRatio = min(1.0, currentRatio+0.1)
 	}
-	
+
 	// If GPU is overloaded, shift more work to CPU
 	if gpuUtil > h.config.MaxGPUUtilization && cpuUtil < h.config.MaxCPUUtilization {
 		newRatio = max(0.0, currentRatio-0.1)
 	}
-	
+
 	// If both are underutilized, prefer GPU for better throughput
 	if cpuUtil < 0.5 && gpuUtil < 0.5 && h.stats.CurrentTPS < h.config.ThroughputTarget {
 		newRatio = min(1.0, currentRatio+0.05)
 	}
-	
+
 	// Apply adjustment
 	if newRatio != currentRatio {
 		h.loadBalancer.adaptiveRatio = newRatio
 		h.loadBalancer.lastAdjustment = time.Now()
-		
+
 		log.Debug("Load balancing ratio adjusted",
 			"oldRatio", currentRatio,
 			"newRatio", newRatio,
@@ -661,30 +680,30 @@ func (h *HybridProcessor) adjustLoadBalancing() {
 func (h *HybridProcessor) GetStats() HybridStats {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	
+
 	return h.stats
 }
 
 // Close gracefully shuts down the hybrid processor
 func (h *HybridProcessor) Close() error {
 	log.Info("Shutting down hybrid processor...")
-	
+
 	// Cancel context
 	h.cancel()
-	
+
 	// Wait for background goroutines
 	h.wg.Wait()
-	
+
 	// Close CPU processor
 	if h.cpuProcessor != nil {
 		h.cpuProcessor.Close()
 	}
-	
+
 	// Close GPU processor
 	if h.gpuProcessor != nil {
 		h.gpuProcessor.Close()
 	}
-	
+
 	log.Info("Hybrid processor shutdown complete")
 	return nil
 }
@@ -712,7 +731,7 @@ func InitGlobalHybridProcessor(config *HybridConfig) error {
 	if globalHybridProcessor != nil {
 		globalHybridProcessor.Close()
 	}
-	
+
 	var err error
 	globalHybridProcessor, err = NewHybridProcessor(config)
 	return err
@@ -726,7 +745,9 @@ func GetGlobalHybridProcessor() *HybridProcessor {
 // CloseGlobalHybridProcessor closes the global hybrid processor
 func CloseGlobalHybridProcessor() error {
 	if globalHybridProcessor != nil {
-		return globalHybridProcessor.Close()
+		err := globalHybridProcessor.Close()
+		globalHybridProcessor = nil
+		return err
 	}
 	return nil
 }

--- a/Core-Blockchain/node_src/miner/worker.go
+++ b/Core-Blockchain/node_src/miner/worker.go
@@ -21,8 +21,8 @@ import (
 	"bytes"
 	"errors"
 	"math/big"
-	"runtime"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -30,6 +30,8 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/ai"
+	"github.com/ethereum/go-ethereum/common/hybrid"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core"
@@ -39,8 +41,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/ethereum/go-ethereum/common/hybrid"
-	"github.com/ethereum/go-ethereum/common/ai"
 )
 
 const (
@@ -49,7 +49,7 @@ const (
 
 	// txChanSize is the size of channel listening to NewTxsEvent.
 	// The number is referenced from the size of tx pool.
-	txChanSize = 100000  // 24x increase for massive transaction volumes
+	txChanSize = 100000 // 24x increase for massive transaction volumes
 
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 100
@@ -65,11 +65,11 @@ const (
 
 	// minRecommitInterval is the minimal time interval to recreate the mining block with
 	// any newly arrived transactions.
-	minRecommitInterval = 50 * time.Millisecond  // 20x faster for high TPS
+	minRecommitInterval = 50 * time.Millisecond // 20x faster for high TPS
 
 	// maxRecommitInterval is the maximum time interval to recreate the mining block with
 	// any newly arrived transactions.
-	maxRecommitInterval = 500 * time.Millisecond  // 30x faster for high TPS
+	maxRecommitInterval = 500 * time.Millisecond // 30x faster for high TPS
 
 	// intervalAdjustRatio is the impact a single interval adjustment has on sealing work
 	// resubmitting interval.
@@ -142,15 +142,17 @@ type worker struct {
 	isPoSA bool
 
 	// GPU/Hybrid processing integration
-	hybridProcessor    *hybrid.HybridProcessor
-	parallelProcessor  *core.ParallelStateProcessor
-	aiLoadBalancer     *ai.AILoadBalancer
-	gpuEnabled         bool
-	batchThreshold     int
-	lastBatchSize      int
-	lastBatchTime      time.Duration
-	adaptiveBatching   bool
-	aiOptimization     bool
+	hybridProcessor        *hybrid.HybridProcessor
+	parallelProcessor      *core.ParallelStateProcessor
+	aiLoadBalancer         *ai.AILoadBalancer
+	gpuEnabled             bool
+	batchThreshold         int
+	lastBatchSize          int
+	lastBatchTime          time.Duration
+	adaptiveBatching       bool
+	aiOptimization         bool
+	hybridThroughputTarget uint64
+	hybridMaxBatchSize     int
 
 	// Feeds
 	pendingLogsFeed event.Feed
@@ -216,38 +218,48 @@ type worker struct {
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, init bool) *worker {
 	posa, isPoSA := engine.(consensus.PoSA)
 	worker := &worker{
-		config:             config,
-		chainConfig:        chainConfig,
-		engine:             engine,
-		isPoSA:             isPoSA,
-		posa:               posa,
-		eth:                eth,
-		mux:                mux,
-		chain:              eth.BlockChain(),
-		isLocalBlock:       isLocalBlock,
-		localUncles:        make(map[common.Hash]*types.Block),
-		remoteUncles:       make(map[common.Hash]*types.Block),
-		unconfirmed:        newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
-		pendingTasks:       make(map[common.Hash]*task),
-		txsCh:              make(chan core.NewTxsEvent, txChanSize),
-		chainHeadCh:        make(chan core.ChainHeadEvent, chainHeadChanSize),
-		chainSideCh:        make(chan core.ChainSideEvent, chainSideChanSize),
-		newWorkCh:          make(chan *newWorkReq),
-		taskCh:             make(chan *task),
-		resultCh:           make(chan *types.Block, resultQueueSize),
-		exitCh:             make(chan struct{}),
-		startCh:            make(chan struct{}, 1),
-		resubmitIntervalCh: make(chan time.Duration),
-		resubmitAdjustCh:   make(chan *intervalAdjust, resubmitAdjustChanSize),
-		batchThreshold:     1000,  // 1K threshold for GPU activation (500+ transactions trigger GPU)
-		adaptiveBatching:   true,  // Enable adaptive batch sizing for 1M+ transactions
-		aiOptimization:     true, // Enable AI-driven optimization
+		config:                 config,
+		chainConfig:            chainConfig,
+		engine:                 engine,
+		isPoSA:                 isPoSA,
+		posa:                   posa,
+		eth:                    eth,
+		mux:                    mux,
+		chain:                  eth.BlockChain(),
+		isLocalBlock:           isLocalBlock,
+		localUncles:            make(map[common.Hash]*types.Block),
+		remoteUncles:           make(map[common.Hash]*types.Block),
+		unconfirmed:            newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
+		pendingTasks:           make(map[common.Hash]*task),
+		txsCh:                  make(chan core.NewTxsEvent, txChanSize),
+		chainHeadCh:            make(chan core.ChainHeadEvent, chainHeadChanSize),
+		chainSideCh:            make(chan core.ChainSideEvent, chainSideChanSize),
+		newWorkCh:              make(chan *newWorkReq),
+		taskCh:                 make(chan *task),
+		resultCh:               make(chan *types.Block, resultQueueSize),
+		exitCh:                 make(chan struct{}),
+		startCh:                make(chan struct{}, 1),
+		resubmitIntervalCh:     make(chan time.Duration),
+		resubmitAdjustCh:       make(chan *intervalAdjust, resubmitAdjustChanSize),
+		batchThreshold:         1000, // 1K threshold for GPU activation (500+ transactions trigger GPU)
+		adaptiveBatching:       true, // Enable adaptive batch sizing for 1M+ transactions
+		aiOptimization:         true, // Enable AI-driven optimization
+		hybridThroughputTarget: 3000000,
+		hybridMaxBatchSize:     200000,
 	}
-	
+
 	// Initialize hybrid processor for GPU acceleration
 	hybridProcessor := hybrid.GetGlobalHybridProcessor()
 	if hybridProcessor != nil {
 		worker.hybridProcessor = hybridProcessor
+		if config := hybridProcessor.GetConfig(); config != nil {
+			if config.ThroughputTarget > 0 {
+				worker.hybridThroughputTarget = config.ThroughputTarget
+			}
+			if config.GPUConfig != nil && config.GPUConfig.MaxBatchSize > 0 {
+				worker.hybridMaxBatchSize = config.GPUConfig.MaxBatchSize
+			}
+		}
 		// Check if GPU is enabled by looking at the hybrid processor's configuration
 		stats := hybridProcessor.GetStats()
 		worker.gpuEnabled = stats.GPUProcessed > 0 || stats.GPUUtilization >= 0
@@ -255,7 +267,14 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 	} else {
 		log.Info("Miner running in CPU-only mode")
 	}
-	
+
+	if v, err := strconv.ParseUint(os.Getenv("THROUGHPUT_TARGET"), 10, 64); err == nil && v > 0 {
+		worker.hybridThroughputTarget = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("GPU_MAX_BATCH_SIZE")); err == nil && v > 0 {
+		worker.hybridMaxBatchSize = v
+	}
+
 	// Initialize AI load balancer for intelligent optimization
 	aiLoadBalancer := ai.GetGlobalAILoadBalancer()
 	if aiLoadBalancer != nil {
@@ -265,31 +284,31 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		log.Info("Miner AI optimization not available")
 		worker.aiOptimization = false
 	}
-	
+
 	// Initialize parallel state processor for advanced parallel processing
 	parallelConfig := core.DefaultParallelProcessorConfig()
 	// Optimize for full CPU utilization while reserving resources for MobileLLM-R1
 	cpuCores := runtime.NumCPU()
-	parallelConfig.TxBatchSize = 100000  // 1000x larger - match GPU's capability
-	parallelConfig.MaxTxConcurrency = cpuCores * 12  // Use 75% of CPU cores (leave 25% for AI)
-	parallelConfig.MaxMemoryUsage = 6 * 1024 * 1024 * 1024  // 6GB RAM (leave room for AI)
-	parallelConfig.MaxGoroutines = cpuCores * 24    // Aggressive parallelization
-	parallelConfig.StateWorkers = cpuCores * 2      // Full CPU state processing
-	parallelConfig.MaxValidationWorkers = cpuCores * 2 // Full CPU validation
-	
+	parallelConfig.TxBatchSize = 100000                    // 1000x larger - match GPU's capability
+	parallelConfig.MaxTxConcurrency = cpuCores * 12        // Use 75% of CPU cores (leave 25% for AI)
+	parallelConfig.MaxMemoryUsage = 6 * 1024 * 1024 * 1024 // 6GB RAM (leave room for AI)
+	parallelConfig.MaxGoroutines = cpuCores * 24           // Aggressive parallelization
+	parallelConfig.StateWorkers = cpuCores * 2             // Full CPU state processing
+	parallelConfig.MaxValidationWorkers = cpuCores * 2     // Full CPU validation
+
 	log.Info("Configuring parallel processing for full hardware utilization",
 		"cpuCores", cpuCores,
 		"maxConcurrency", parallelConfig.MaxTxConcurrency,
 		"maxGoroutines", parallelConfig.MaxGoroutines,
 		"reservedForAI", "25% CPU + 6GB GPU for MobileLLM-R1")
-	
+
 	var err error
 	worker.parallelProcessor, err = core.NewParallelStateProcessor(chainConfig, eth.BlockChain(), engine, parallelConfig)
 	if err != nil {
 		log.Error("Failed to create parallel state processor", "err", err)
 		worker.parallelProcessor = nil
 	} else {
-		log.Info("Miner parallel processing initialized", 
+		log.Info("Miner parallel processing initialized",
 			"txBatchSize", parallelConfig.TxBatchSize,
 			"maxConcurrency", parallelConfig.MaxTxConcurrency,
 			"pipelining", parallelConfig.EnablePipelining)
@@ -884,18 +903,18 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	if w.gpuEnabled && w.hybridProcessor != nil {
 		// Calculate optimal batch size based on performance
 		optimalBatchSize := w.calculateOptimalBatchSize()
-		
+
 		// Collect transactions into a batch for potential GPU processing
 		var txBatch []*types.Transaction
 		tempTxs := txs
-		
+
 		// Collect up to optimal batch size transactions for GPU processing
 		for len(txBatch) < optimalBatchSize {
 			tx := tempTxs.Peek()
 			if tx == nil {
 				break
 			}
-			
+
 			// Basic validation before adding to batch
 			from, _ := types.Sender(w.current.signer, tx)
 			if tx.Protected() && !w.chainConfig.IsEIP155(w.current.header.Number) {
@@ -908,23 +927,23 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 					continue
 				}
 			}
-			
+
 			txBatch = append(txBatch, tx)
 			tempTxs.Shift()
 		}
-		
+
 		// Process batch with GPU if we have enough transactions
 		if len(txBatch) >= w.batchThreshold/2 { // Use GPU for batches >= 500 transactions (1000/2)
 			batchStart := time.Now()
 			log.Debug("Processing transaction batch with GPU acceleration", "batchSize", len(txBatch))
-			
+
 			// Use hybrid processor for GPU-accelerated prevalidation
 			err := w.hybridProcessor.ProcessTransactionsBatch(txBatch, func(results []*hybrid.TransactionResult, err error) {
 				if err != nil {
 					log.Warn("GPU batch processing failed, falling back to sequential", "error", err)
 					return
 				}
-				
+
 				// Apply GPU-validated transactions sequentially (EVM execution still needs to be sequential for state consistency)
 				for i, result := range results {
 					if result.Valid && i < len(txBatch) {
@@ -938,11 +957,11 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 					}
 				}
 			})
-			
+
 			// Update batch performance metrics
 			batchDuration := time.Since(batchStart)
 			w.updateBatchPerformance(len(txBatch), batchDuration)
-			
+
 			if err != nil {
 				log.Warn("Failed to submit GPU batch, falling back to sequential processing", "error", err)
 			} else {
@@ -1161,14 +1180,14 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 	// Fill the block with all available pending transactions.
 	pending := w.eth.TxPool().Pending(true)
-	
+
 	// Create an empty block based on temporary copied state for
 	// sealing in advance without waiting block execution finished.
 	// BUT ONLY if there are no pending transactions to avoid empty blocks when we have transactions
 	if !noempty && atomic.LoadUint32(&w.noempty) == 0 && len(pending) == 0 {
 		w.commit(uncles, nil, false, tstart)
 	}
-	
+
 	// Short circuit if there is no available pending transactions.
 	// But if we disable empty precommit already, ignore it. Since
 	// empty block is necessary to keep the liveness of the network.
@@ -1179,20 +1198,20 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 	// Estimate total transaction count for parallel processing decision
 	totalTxCount := w.estimateTransactionCount(pending)
-	
+
 	// Use parallel processor for massive transaction batches (100K+ transactions)
 	if w.parallelProcessor != nil && totalTxCount >= 100000 {
-		log.Info("Using parallel processor for massive transaction batch", 
-			"totalTxs", totalTxCount, 
+		log.Info("Using parallel processor for massive transaction batch",
+			"totalTxs", totalTxCount,
 			"threshold", 100000,
 			"parallelBatchSize", 100000)
-		
+
 		// Combine all transactions for parallel processing
 		allTxs := make([]*types.Transaction, 0, totalTxCount)
 		for _, txList := range pending {
 			allTxs = append(allTxs, txList...)
 		}
-		
+
 		if len(allTxs) > 0 {
 			// Create a temporary block for parallel processing
 			tempBlock := types.NewBlock(
@@ -1202,44 +1221,44 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 				nil, // no receipts yet
 				trie.NewStackTrie(nil),
 			)
-			
+
 			batchStart := time.Now()
-			
+
 			// Process ALL transactions with parallel processor
 			receipts, logs, gasUsed, err := w.parallelProcessor.ProcessParallel(
-				tempBlock, 
-				w.current.state, 
+				tempBlock,
+				w.current.state,
 				*w.chain.GetVMConfig(),
 			)
-			
+
 			batchDuration := time.Since(batchStart)
-			
+
 			if err != nil {
-				log.Warn("Massive parallel processing failed, falling back to standard processing", 
-					"error", err, 
+				log.Warn("Massive parallel processing failed, falling back to standard processing",
+					"error", err,
 					"txCount", len(allTxs))
 				// Fall through to standard processing
 			} else {
 				// Parallel processing succeeded for massive batch
-				log.Info("MASSIVE parallel processing completed successfully", 
+				log.Info("MASSIVE parallel processing completed successfully",
 					"txCount", len(allTxs),
 					"gasUsed", gasUsed,
 					"duration", batchDuration,
 					"tps", float64(len(allTxs))/batchDuration.Seconds(),
 					"logCount", len(logs))
-				
+
 				// Update current state with results
 				w.current.txs = append(w.current.txs, allTxs...)
 				w.current.receipts = append(w.current.receipts, receipts...)
 				w.current.tcount += len(allTxs)
 				w.current.header.GasUsed += gasUsed
-				
+
 				// Ensure gasPool is initialized before using it
 				if w.current.gasPool == nil {
 					w.current.gasPool = new(core.GasPool).AddGas(w.current.header.GasLimit)
 				}
 				w.current.gasPool.SubGas(gasUsed)
-				
+
 				// Skip standard processing since parallel processing handled everything
 				// But we still need to commit the block with the processed transactions
 				w.commit(uncles, w.fullTaskHook, true, tstart)
@@ -1247,7 +1266,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			}
 		}
 	}
-	
+
 	// Standard processing for smaller batches or if parallel processing failed
 	// Split the pending transactions into locals and remotes
 	localTxs, remoteTxs := make(map[common.Address]types.Transactions), pending
@@ -1257,7 +1276,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			localTxs[account] = txs
 		}
 	}
- 	if len(localTxs) > 0 {
+	if len(localTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs, header.BaseFee)
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
 			w.current.state.StopPrefetcher()
@@ -1332,13 +1351,13 @@ func (w *worker) calculateOptimalBatchSize() int {
 	if !w.adaptiveBatching || w.hybridProcessor == nil {
 		return w.batchThreshold
 	}
-	
+
 	// Get current hybrid processor stats
 	stats := w.hybridProcessor.GetStats()
-	
+
 	// Base batch size
 	baseBatchSize := w.batchThreshold
-	
+
 	// Use AI recommendations if available
 	if w.aiOptimization && w.aiLoadBalancer != nil {
 		aiStats := w.aiLoadBalancer.GetStats()
@@ -1358,7 +1377,7 @@ func (w *worker) calculateOptimalBatchSize() int {
 			log.Debug("Using AI-recommended strategy", "strategy", aiStats.LastPrediction.RecommendedStrategy, "confidence", aiStats.LastPrediction.Confidence)
 		}
 	}
-	
+
 	// Adjust based on GPU utilization
 	if stats.GPUUtilization < 0.5 {
 		// GPU underutilized, increase batch size
@@ -1367,15 +1386,12 @@ func (w *worker) calculateOptimalBatchSize() int {
 		// GPU overloaded, decrease batch size
 		baseBatchSize = int(float64(baseBatchSize) * 0.8)
 	}
-	
-	// Adjust based on current TPS vs target (read from env or default to hybrid goal)
-	parseUint := func(s string, def uint64) uint64 {
-		if s == "" { return def }
-		if v, err := strconv.ParseUint(s, 10, 64); err == nil { return v }
-		return def
+
+	// Adjust based on current TPS vs target (cached from hybrid config or environment overrides)
+	targetTPS := w.hybridThroughputTarget
+	if targetTPS == 0 {
+		targetTPS = 3000000
 	}
-    // Default aligns with hybrid.DefaultHybridConfig and geth init (3M)
-    targetTPS := parseUint(os.Getenv("THROUGHPUT_TARGET"), 3000000)
 	// Be more aggressive below 70% of target, stabilize above 95%
 	if stats.CurrentTPS < (targetTPS*70)/100 {
 		baseBatchSize = int(float64(baseBatchSize) * 1.25)
@@ -1383,7 +1399,7 @@ func (w *worker) calculateOptimalBatchSize() int {
 		// Near/at target: keep current size
 		// no-op
 	}
-	
+
 	// Adjust based on previous batch performance
 	if w.lastBatchTime > 0 && w.lastBatchSize > 0 {
 		// If last batch was slow, reduce size
@@ -1394,25 +1410,24 @@ func (w *worker) calculateOptimalBatchSize() int {
 			baseBatchSize = int(float64(w.lastBatchSize) * 1.1)
 		}
 	}
-	
+
 	// Enforce bounds (respect environment and threshold)
 	minBatchSize := 500
 	if w.batchThreshold > minBatchSize {
 		minBatchSize = w.batchThreshold
 	}
-	// Default max aligned with cmd/geth/main.go (env default 80K)
-    maxDefault := 200000
-	if v, err := strconv.Atoi(os.Getenv("GPU_MAX_BATCH_SIZE")); err == nil && v > 0 {
-		maxDefault = v
+	// Default max aligned with cached hybrid configuration
+	maxBatchSize := w.hybridMaxBatchSize
+	if maxBatchSize <= 0 {
+		maxBatchSize = 200000
 	}
-	maxBatchSize := maxDefault
-	
+
 	if baseBatchSize < minBatchSize {
 		baseBatchSize = minBatchSize
 	} else if baseBatchSize > maxBatchSize {
 		baseBatchSize = maxBatchSize
 	}
-	
+
 	return baseBatchSize
 }
 
@@ -1420,16 +1435,16 @@ func (w *worker) calculateOptimalBatchSize() int {
 func (w *worker) updateBatchPerformance(batchSize int, duration time.Duration) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	
+
 	w.lastBatchSize = batchSize
 	w.lastBatchTime = duration
-	
+
 	// Log performance for monitoring
 	if duration > 0 {
 		tps := float64(batchSize) / duration.Seconds()
-		log.Debug("GPU batch performance", 
-			"batchSize", batchSize, 
-			"duration", duration, 
+		log.Debug("GPU batch performance",
+			"batchSize", batchSize,
+			"duration", duration,
 			"tps", tps,
 		)
 	}
@@ -1439,15 +1454,15 @@ func (w *worker) updateBatchPerformance(batchSize int, duration time.Duration) {
 func (w *worker) GetMinerStats() map[string]interface{} {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	
+
 	stats := map[string]interface{}{
-		"gpu_enabled":      w.gpuEnabled,
-		"batch_threshold":  w.batchThreshold,
-		"last_batch_size":  w.lastBatchSize,
-		"last_batch_time":  w.lastBatchTime,
+		"gpu_enabled":       w.gpuEnabled,
+		"batch_threshold":   w.batchThreshold,
+		"last_batch_size":   w.lastBatchSize,
+		"last_batch_time":   w.lastBatchTime,
 		"adaptive_batching": w.adaptiveBatching,
 	}
-	
+
 	if w.hybridProcessor != nil {
 		hybridStats := w.hybridProcessor.GetStats()
 		stats["hybrid_stats"] = map[string]interface{}{
@@ -1460,11 +1475,11 @@ func (w *worker) GetMinerStats() map[string]interface{} {
 			"load_balancing_ratio": hybridStats.LoadBalancingRatio,
 		}
 	}
-	
+
 	return stats
 }
 
-// collectAllTransactions converts TransactionsByPriceAndNonce to a slice 
+// collectAllTransactions converts TransactionsByPriceAndNonce to a slice
 // Note: This consumes the iterator, so should only be called when we're going to use parallel processing
 func (w *worker) collectAllTransactions(txs *types.TransactionsByPriceAndNonce) []*types.Transaction {
 	var allTxs []*types.Transaction

--- a/Core-Blockchain/node_src/miner/worker_test.go
+++ b/Core-Blockchain/node_src/miner/worker_test.go
@@ -20,12 +20,14 @@ package miner
 import (
 	"math/big"
 	"math/rand"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hybrid"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
@@ -520,5 +522,87 @@ func testAdjustInterval(t *testing.T, chainConfig *params.ChainConfig, engine co
 	case <-progress:
 	case <-time.NewTimer(time.Second).C:
 		t.Error("interval reset timeout")
+	}
+}
+
+func TestWorkerRespectsHybridConfigWithoutEnv(t *testing.T) {
+	prevTarget, targetSet := os.LookupEnv("THROUGHPUT_TARGET")
+	if targetSet {
+		t.Cleanup(func() {
+			os.Setenv("THROUGHPUT_TARGET", prevTarget)
+		})
+	} else {
+		t.Cleanup(func() {
+			os.Unsetenv("THROUGHPUT_TARGET")
+		})
+	}
+	os.Unsetenv("THROUGHPUT_TARGET")
+
+	prevMaxBatch, maxSet := os.LookupEnv("GPU_MAX_BATCH_SIZE")
+	if maxSet {
+		t.Cleanup(func() {
+			os.Setenv("GPU_MAX_BATCH_SIZE", prevMaxBatch)
+		})
+	} else {
+		t.Cleanup(func() {
+			os.Unsetenv("GPU_MAX_BATCH_SIZE")
+		})
+	}
+	os.Unsetenv("GPU_MAX_BATCH_SIZE")
+
+	prevHybrid := hybrid.GetGlobalHybridProcessor()
+	if prevHybrid != nil {
+		prevConfig := prevHybrid.GetConfig()
+		t.Cleanup(func() {
+			if err := hybrid.InitGlobalHybridProcessor(prevConfig); err != nil {
+				t.Errorf("failed to restore hybrid processor: %v", err)
+			}
+		})
+	} else {
+		t.Cleanup(func() {
+			if err := hybrid.CloseGlobalHybridProcessor(); err != nil {
+				t.Errorf("failed to reset hybrid processor: %v", err)
+			}
+		})
+	}
+
+	const expectedTPS = uint64(9000000)
+	const expectedMaxBatch = 1200000
+
+	customConfig := hybrid.DefaultHybridConfig()
+	customConfig.ThroughputTarget = expectedTPS
+	if customConfig.GPUConfig != nil {
+		customConfig.GPUConfig.MaxBatchSize = expectedMaxBatch
+	}
+
+	if err := hybrid.InitGlobalHybridProcessor(customConfig); err != nil {
+		t.Fatalf("failed to initialize hybrid processor: %v", err)
+	}
+
+	engine := ethash.NewFaker()
+	defer engine.Close()
+
+	chainConfig := new(params.ChainConfig)
+	*chainConfig = *params.AllEthashProtocolChanges
+
+	w, backend := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), 0)
+	defer backend.chain.Stop()
+	defer w.close()
+
+	if w.hybridProcessor == nil {
+		t.Fatal("expected hybrid processor to be wired for worker")
+	}
+	if w.hybridThroughputTarget != expectedTPS {
+		t.Fatalf("hybrid throughput target mismatch: have %d want %d", w.hybridThroughputTarget, expectedTPS)
+	}
+	if w.hybridMaxBatchSize != expectedMaxBatch {
+		t.Fatalf("hybrid max batch size mismatch: have %d want %d", w.hybridMaxBatchSize, expectedMaxBatch)
+	}
+
+	// Force the adaptive algorithm to request more than the configured max batch size.
+	w.batchThreshold = 900000
+	batchSize := w.calculateOptimalBatchSize()
+	if batchSize != expectedMaxBatch {
+		t.Fatalf("expected batch size to honor hybrid max batch size, got %d want %d", batchSize, expectedMaxBatch)
 	}
 }


### PR DESCRIPTION
## Summary
- expose `(*HybridProcessor).GetConfig` to provide a defensive copy for consumers and clear the global pointer when closing the processor
- cache the hybrid throughput target and GPU max batch size in the miner worker, honoring HybridConfig defaults and any env overrides
- reuse the cached values inside `calculateOptimalBatchSize` and extend worker tests to cover custom HybridConfig defaults without env vars

## Testing
- go test ./miner -run TestWorkerRespectsHybridConfigWithoutEnv *(fails: C source files not allowed when not using cgo or SWIG: opencl_stubs.c)*

------
https://chatgpt.com/codex/tasks/task_e_68ca21ebce508324bc85ebee761c83d9