### PR TITLE
Raise ETH/SNAP max message size to 1 GiB

### DIFF
--- a/Core-Blockchain/node_src/eth/protocols/eth/protocol.go
+++ b/Core-Blockchain/node_src/eth/protocols/eth/protocol.go
@@ -46,8 +46,9 @@ var ProtocolVersions = []uint{ETH66}
 // different protocol versions.
 var protocolLengths = map[uint]uint64{ETH66: 17}
 
-// maxMessageSize is the maximum cap on the size of a protocol message.
-const maxMessageSize = 10 * 1024 * 1024
+// maxMessageSize caps the size of protocol messages; set to 1 GiB to safely
+// envelope exceptionally large RLP-encoded blocks.
+const maxMessageSize = 1024 * 1024 * 1024
 
 const (
 	StatusMsg                     = 0x00

--- a/Core-Blockchain/node_src/eth/protocols/snap/protocol.go
+++ b/Core-Blockchain/node_src/eth/protocols/snap/protocol.go
@@ -43,8 +43,9 @@ var ProtocolVersions = []uint{snap1}
 // different protocol versions.
 var protocolLengths = map[uint]uint64{snap1: 8}
 
-// maxMessageSize is the maximum cap on the size of a protocol message.
-const maxMessageSize = 10 * 1024 * 1024
+// maxMessageSize caps the size of protocol messages; set to 1 GiB to safely
+// envelope exceptionally large RLP-encoded block bodies.
+const maxMessageSize = 1024 * 1024 * 1024
 
 const (
 	GetAccountRangeMsg  = 0x00


### PR DESCRIPTION
## Summary
- raise the ETH protocol message cap to 1 GiB so large RLP-encoded blocks do not overflow the envelope
- apply the same 1 GiB cap in the SNAP protocol to accept large block body responses

## Testing
- `make geth` *(fails: C source files not allowed when not using cgo or SWIG: opencl_stubs.c)*
- `go build -tags gpu ./cmd/geth` *(fails: fatal error: oqs/oqs.h: No such file or directory; missing OpenCL headers)*

------
https://chatgpt.com/codex/tasks/task_e_68cb63dcebcc83249ee76ee17486a639